### PR TITLE
lookahead keep tail

### DIFF
--- a/src/cell_tree_agent.hpp
+++ b/src/cell_tree_agent.hpp
@@ -92,7 +92,7 @@ struct CellTreeAgent : Agent {
 public:
   // config
   bool recalculate_path = true;
-  Lookahead lookahead = Lookahead::many_move_tail;
+  Lookahead lookahead = Lookahead::many_keep_tail;
   DetourStrategy detour = DetourStrategy::nearest_unreachable;
   // penalties
   int same_cell_penalty = 0;

--- a/src/game_util.hpp
+++ b/src/game_util.hpp
@@ -171,7 +171,7 @@ Grid<Coord> random_spanning_tree(CoordRange dims, RNG& rng) {
     }
   }
   while (!queue.empty()) {
-    int i = rng.random(queue.size());
+    int i = rng.random(static_cast<int>(queue.size()));
     Coord parent = queue[i].first;
     Coord node   = queue[i].second;
     queue[i] = queue.back();


### PR DESCRIPTION
addresses https://github.com/twanvl/snake/issues/2

running ```snake.exe all``` on master is broken and it seems to be due to using ```Lookahead::many_move_tail``` for cell tree algo by default instead of ```Lookahead::many_keep_tail```

using the later fixes ```snake.exe all``` and reproduces results consistent with the README.

![image](https://github.com/user-attachments/assets/fe8c5beb-3fb4-46a9-87d9-323ed8f530f8)