### PR TITLE
many_move_tail fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 build/
 ideas/
+*.json
+*.exe
+.vscode/
+*.log
+.DS_Store
+.github/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Currently does not include "nascar" or "applefear" modes.
 
 ## Results
 
-Number of steps to finish the game on a 20×20 grid (over 100 runs)
+Number of steps to finish the game on a 30×30 grid (over 100 runs)
 
 |agent          |mean     |stddev   |min      |q.25     |median   |q.75     |max      |lost      |
 |---------------|---------|---------|---------|---------|---------|---------|---------|----------|

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Currently does not include "nascar" or "applefear" modes.
 
 ## Results
 
-Number of steps to finish the game on a 30×30 grid (over 100 runs)
+Number of steps to finish the game on a 20×20 grid (over 100 runs)
 
 |agent          |mean     |stddev   |min      |q.25     |median   |q.75     |max      |lost      |
 |---------------|---------|---------|---------|---------|---------|---------|---------|----------|

--- a/src/cell_tree_agent.hpp
+++ b/src/cell_tree_agent.hpp
@@ -96,11 +96,11 @@ Unreachables get_unreachables_from_lookahead(
     Lookahead lookahead, 
     const Grid<Step>& dists) {
   if (lookahead == Lookahead::many_move_tail) {
-    auto after_move_tail = after_moves(game, path, Lookahead::many_move_tail);
-    auto unreachable_move_tail = cell_tree_unreachables(after_move_tail, dists);
+    auto after = after_moves(game, path, Lookahead::many_move_tail);
+    auto unreachable = cell_tree_unreachables(after, dists);
     
-    if (!unreachable_move_tail.any) {
-      return unreachable_move_tail;
+    if (!unreachable.any) {
+      return unreachable;
     } else {
       auto after_keep_tail = after_moves(game, path, Lookahead::many_keep_tail);
       auto unreachable_keep_tail = cell_tree_unreachables(after_keep_tail, dists);

--- a/src/cell_tree_agent.hpp
+++ b/src/cell_tree_agent.hpp
@@ -102,9 +102,9 @@ Unreachables get_unreachables_from_lookahead(
     if (!unreachable.any) {
       return unreachable;
     } else {
-      auto after_keep_tail = after_moves(game, path, Lookahead::many_keep_tail);
-      auto unreachable_keep_tail = cell_tree_unreachables(after_keep_tail, dists);
-      return unreachable_keep_tail;
+      auto after = after_moves(game, path, Lookahead::many_keep_tail);
+      auto unreachable = cell_tree_unreachables(after, dists);
+      return unreachable;
     }
   } else {
     auto after = after_moves(game, path, lookahead);

--- a/src/cell_tree_agent.hpp
+++ b/src/cell_tree_agent.hpp
@@ -73,6 +73,28 @@ Dir move_to_parent(Grid<Coord> const& cell_parents, Coord a) {
   throw "move_to_parent";
 }
 
+Unreachables& get_unreachables_from_lookahead(
+    const GameBase& game, 
+    const std::vector<Coord>& path, 
+    Lookahead lookahead, 
+    const Grid<Step>& dists) {
+  if (lookahead == Lookahead::many_move_tail) {
+    auto after_move_tail = after_moves(game, path, Lookahead::many_move_tail);
+    auto unreachable_move_tail = cell_tree_unreachables(after_move_tail, dists);
+    
+    if (!unreachable_move_tail.any) {
+      return unreachable_move_tail;
+    } else {
+      auto after_keep_tail = after_moves(game, path, Lookahead::many_keep_tail);
+      auto unreachable_keep_tail = cell_tree_unreachables(after_keep_tail, dists);
+      return unreachable_keep_tail;
+    }
+  } else {
+    auto after = after_moves(game, path, lookahead);
+    auto unreachable = cell_tree_unreachables(after, dists);
+    return unreachable;
+  }
+}
 
 Unreachables cell_tree_unreachables(GameBase const& game, Grid<Step> const& dists) {
   auto cell_parents = cell_tree_parents(game.dimensions(), game.snake);
@@ -156,9 +178,9 @@ public:
     }
     
     // Heuristic 3: prevent making parts of the grid unreachable
-    if (detour != DetourStrategy::none) {
-      auto after = after_moves(game, path, lookahead);
-      auto unreachable = cell_tree_unreachables(after, dists);
+    if (detour != DetourStrategy::none) {    
+      const Unreachables& unreachable = get_unreachables_from_lookahead(game, path, lookahead, dists);
+      
       if (unreachable.any) {
         if (log) {
           Grid<bool> unreachable_grid(game.dimensions());

--- a/src/cell_tree_agent.hpp
+++ b/src/cell_tree_agent.hpp
@@ -90,7 +90,7 @@ bool should_use_cached_path_for_move_tail(const Unreachables& unreachable, Looka
   return false;
 }
 
-Unreachables get_unreachables_from_lookahead(
+Unreachables get_unreachables(
     const GameBase& game, 
     const std::vector<Coord>& path, 
     Lookahead lookahead, 
@@ -188,7 +188,7 @@ public:
     
     // Heuristic 3: prevent making parts of the grid unreachable
     if (detour != DetourStrategy::none) {    
-      const Unreachables unreachable = get_unreachables_from_lookahead(game, path, lookahead, dists);
+      const Unreachables unreachable = get_unreachables(game, path, lookahead, dists);
       if (should_use_cached_path_for_move_tail(unreachable, lookahead, cached_path)) {
         pos2 = cached_path.back();
         cached_path.pop_back();

--- a/src/cell_tree_agent.hpp
+++ b/src/cell_tree_agent.hpp
@@ -104,6 +104,15 @@ Unreachables cell_tree_unreachables(GameBase const& game, Grid<Step> const& dist
   return unreachables(can_move, game, dists);
 }
 
+bool should_use_cached_path_for_move_tail(const Unreachables& unreachable, Lookahead lookahead, const std::vector<Coord>& cached_path) {
+  if (lookahead == Lookahead::many_move_tail) {
+    if ((unreachable.any) && (unreachable.dist_to_farthest >= INT_MAX) && !cached_path.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 enum class DetourStrategy {
   none,
   any,
@@ -180,6 +189,11 @@ public:
     // Heuristic 3: prevent making parts of the grid unreachable
     if (detour != DetourStrategy::none) {    
       const Unreachables& unreachable = get_unreachables_from_lookahead(game, path, lookahead, dists);
+      if (should_use_cached_path_for_move_tail(unreachable, lookahead, cached_path)) {
+        pos2 = cached_path.back();
+        cached_path.pop_back();
+        return pos2 - pos;
+      }
       
       if (unreachable.any) {
         if (log) {

--- a/src/game_util.hpp
+++ b/src/game_util.hpp
@@ -171,7 +171,7 @@ Grid<Coord> random_spanning_tree(CoordRange dims, RNG& rng) {
     }
   }
   while (!queue.empty()) {
-    int i = rng.random(queue.size());
+    int i = rng.random(static_cast<int>(queue.size()));
     Coord parent = queue[i].first;
     Coord node   = queue[i].second;
     queue[i] = queue.back();

--- a/src/game_util.hpp
+++ b/src/game_util.hpp
@@ -43,7 +43,9 @@ GameBase after_moves(GameBase const& game, std::vector<Coord> const& path, Looka
 struct Unreachables {
   bool any = false;
   Coord nearest = {-1,-1};
+  Coord farthest = {-1,-1};
   int dist_to_nearest = INT_MAX;
+  int dist_to_farthest = 0;
   Grid<bool> reachable;
   
   Unreachables(Grid<bool> const& reachable)
@@ -67,6 +69,10 @@ Unreachables unreachables(CanMove can_move, GameLike const& game, Grid<Step> con
       if (dists[a].dist < out.dist_to_nearest) {
         out.nearest = a;
         out.dist_to_nearest = dists[a].dist;
+      }
+      if (dists[a].dist > out.dist_to_farthest) {  // track the farthest unreachable coordinate
+        out.farthest = a;
+        out.dist_to_farthest = dists[a].dist;
       }
     }
   }

--- a/src/snake.cpp
+++ b/src/snake.cpp
@@ -449,7 +449,7 @@ Stats play_multiple_threaded(AgentGen make_agent, Config& config) {
     t.join();
   }
   // done
-  if (!config.quiet) std::cout << "\033[K\r";
+  if (!config.quiet) std::cout << std::endl;
   return stats;
 }
 
@@ -467,7 +467,7 @@ Stats play_multiple(AgentGen make_agent, Config& config) {
       std::cout << (i+1) << "/" << config.num_rounds << "  " << stats << "\033[K\r" << std::flush;
     }
   }
-  if (!config.quiet) std::cout << "\033[K\r";
+  if (!config.quiet) std::cout << std::endl;
   return stats;
 }
 


### PR DESCRIPTION
This is per the discussion here: https://github.com/twanvl/snake/issues/2

I am now using the lookahead move tail only if there are no unreachables. If later on going to a shorter path to the apple creates unreachables with INT_MAX on keep tail, then use the cached path.

<img width="681" alt="image" src="https://github.com/user-attachments/assets/37c9c5c4-0f38-42b0-a4b7-3d0791eee910" />